### PR TITLE
Грузим фотки даже если у юзера их всего меньше 200

### DIFF
--- a/src/actions/PageActions.js
+++ b/src/actions/PageActions.js
@@ -30,6 +30,7 @@ function getMorePhotos(offset, count, year, dispatch) {
         photosArr = photosArr.concat(r.response)
         getMorePhotos(offset,count,year,dispatch)
       } else {
+        photosArr = photosArr.concat(r.response)
         let photos = makeYearPhotos(photosArr, year)
         cached = true
         dispatch({


### PR DESCRIPTION
Если у пользователя всего меньше 200 (или сколько в count указано) фотографий, то у него ничего не загружалось. Исправляем.
